### PR TITLE
feature-19: add post deletions service

### DIFF
--- a/src/main/java/com/example/myinsta/controller/PostsController.java
+++ b/src/main/java/com/example/myinsta/controller/PostsController.java
@@ -1,6 +1,7 @@
 package com.example.myinsta.controller;
 
 import com.example.myinsta.dto.PostCreateDto;
+import com.example.myinsta.dto.PostDeleteDto;
 import com.example.myinsta.dto.PostUpdateDto;
 import com.example.myinsta.service.PostsService;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,11 @@ public class PostsController {
     @PatchMapping("/{postId}")
     public ResponseEntity<Void> postUpdate(@PathVariable Long postId, @Valid @RequestBody PostUpdateDto postUpdateDto){
         postService.postUpdate(postUpdateDto, postId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+    @DeleteMapping("/{idPost}")
+    public ResponseEntity<Void> postDelete(@PathVariable Long idPost, @Valid @RequestBody PostDeleteDto postDeleteDto){
+        postService.postDelete(idPost, postDeleteDto);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/myinsta/dto/PostDeleteDto.java
+++ b/src/main/java/com/example/myinsta/dto/PostDeleteDto.java
@@ -1,0 +1,16 @@
+package com.example.myinsta.dto;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import lombok.*;
+
+import javax.validation.constraints.Min;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostDeleteDto {
+    @Min(value = 1, message = "Account Id must greater than or equal to 1")
+    private long idAccount;
+}

--- a/src/main/java/com/example/myinsta/exception/ErrorCode.java
+++ b/src/main/java/com/example/myinsta/exception/ErrorCode.java
@@ -14,7 +14,10 @@ public enum ErrorCode {
     FAILED_TO_UPDATE_POST(803,"Post update failed"),
     FAILED_TO_UPDATE_POST_IMAGE( 804,"Post image update failed" ),
     FAILED_TO_UPDATE_POST_NOT_FOUND( 804,"Post cannot be found" ),
-    FAILED_TO_UPDATE_POST_NOT_OWNER(805, "Only post owner can modify post" );
+    FAILED_TO_UPDATE_POST_NOT_OWNER(805, "Only post owner can modify post" ),
+    FAILED_TO_DELETE_POST(806,"Post deletion failed" ),
+    FAILED_TO_DELETE_POST_NOT_FOUND(807, "Post deletion failed post cannot be found"),
+    FAILED_TO_DELETE_POST_NOT_OWNER(808,"Only post owner can delete post" );
 
     private final int status;
     private final String message;

--- a/src/main/java/com/example/myinsta/mapper/PostsMapper.java
+++ b/src/main/java/com/example/myinsta/mapper/PostsMapper.java
@@ -9,7 +9,7 @@ public interface PostsMapper {
     int insertPostImage(PostImageDao postImageDao);
     int updatePost(PostsUpdateDao postsUpdateDao);
     int updatePostImage(PostImagesUpdateDao postImagesUpdateDao);
-    boolean isPostExist(PostsUpdateDao postsUpdateDao);
-
-    boolean isOwner(PostsUpdateDao postsUpdateDao);
+    boolean isPostExist(Long idPost);
+    boolean isOwner(Long idAccount);
+    int deletePost(Long idPost);
 }

--- a/src/main/java/com/example/myinsta/service/PostsService.java
+++ b/src/main/java/com/example/myinsta/service/PostsService.java
@@ -5,6 +5,7 @@ import com.example.myinsta.dao.PostImagesUpdateDao;
 import com.example.myinsta.dao.PostsDao;
 import com.example.myinsta.dao.PostsUpdateDao;
 import com.example.myinsta.dto.PostCreateDto;
+import com.example.myinsta.dto.PostDeleteDto;
 import com.example.myinsta.dto.PostUpdateDto;
 import com.example.myinsta.exception.CustomException;
 import com.example.myinsta.exception.ErrorCode;
@@ -45,10 +46,10 @@ public class PostsService {
                 .title(postUpdateDto.getTitle())
                 .build();
 
-        if(!postsMapper.isPostExist(postsUpdateDao)){
+        if(!postsMapper.isPostExist(postId)){
             throw new CustomException(ErrorCode.FAILED_TO_UPDATE_POST_NOT_FOUND);
         }
-        if(!postsMapper.isOwner(postsUpdateDao)){
+        if(!postsMapper.isOwner(postsUpdateDao.getIdAccount())){
             throw new CustomException(ErrorCode.FAILED_TO_UPDATE_POST_NOT_OWNER);
         }
         int result = postsMapper.updatePost(postsUpdateDao);
@@ -66,5 +67,16 @@ public class PostsService {
             throw new CustomException(ErrorCode.FAILED_TO_UPDATE_POST_IMAGE);
         }
     }
-
+    public void postDelete(Long idPost, PostDeleteDto postDeleteDto) {
+        if(!postsMapper.isPostExist(idPost)){
+            throw new CustomException(ErrorCode.FAILED_TO_DELETE_POST_NOT_FOUND);
+        }
+        if(!postsMapper.isOwner(postDeleteDto.getIdAccount())){
+            throw new CustomException(ErrorCode.FAILED_TO_DELETE_POST_NOT_OWNER);
+        }
+        int result = postsMapper.deletePost(idPost);
+        if(result != 1){
+            throw new CustomException(ErrorCode.FAILED_TO_DELETE_POST);
+        }
+    }
 }

--- a/src/main/resources/mapper/PostsMapper.xml
+++ b/src/main/resources/mapper/PostsMapper.xml
@@ -23,16 +23,20 @@
         <if test="imagePath != null">image_path = #{imagePath}</if>
         where id_post = #{idPost};
     </update>
-    <select id="isPostExist" parameterType="com.example.myinsta.dao.PostsUpdateDao" resultType="boolean">
+    <select id="isPostExist" resultType="boolean">
         SELECT EXISTS
         (SELECT id_post
         FROM posts
         WHERE id_post = #{idPost});
     </select>
-    <select id="isOwner" parameterType="com.example.myinsta.dao.PostsUpdateDao" resultType="boolean">
+    <select id="isOwner" resultType="boolean">
         SELECT EXISTS
         (SELECT id_post
         FROM posts
         WHERE id_post = #{idPost} AND id_account = #{idAccount})
     </select>
+    <delete id="deletePost">
+        DELETE FROM posts
+        WHERE id_post = #{idPost};
+    </delete>
 </mapper>

--- a/src/test/java/com/example/myinsta/controller/PostsControllerTest.java
+++ b/src/test/java/com/example/myinsta/controller/PostsControllerTest.java
@@ -2,6 +2,7 @@ package com.example.myinsta.controller;
 
 
 import com.example.myinsta.dto.PostCreateDto;
+import com.example.myinsta.dto.PostDeleteDto;
 import com.example.myinsta.dto.PostUpdateDto;
 import com.example.myinsta.service.PostsService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -15,8 +16,7 @@ import org.springframework.http.MediaType;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willDoNothing;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -30,6 +30,7 @@ public class PostsControllerTest {
     PostsService postService;
     private PostCreateDto postCreateDto;
     private PostUpdateDto postUpdateDto;
+    private PostDeleteDto postDeleteDto;
     private String errorCode = "$..errorCode";;
     private String errorMessage = "$..errorMessage";;
 
@@ -252,5 +253,21 @@ public class PostsControllerTest {
                 .andExpect(jsonPath(errorMessage).value("User Id must greater than or equal to 1"))
         ;
     }
+    @Test
+    @DisplayName("postDelete() less than 1 idAccount input")
+    void postDelete_invalid_idAccount_less_than_1() throws Exception {
+        postDeleteDto = PostDeleteDto.builder()
+                .idAccount(0L)
+                .build();
+        willDoNothing().given(postService).postDelete(1L, postDeleteDto);
 
+        mockMvc.perform(delete("/posts/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(postDeleteDto)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath(errorCode).value(700))
+                .andExpect(jsonPath(errorMessage).value("Account Id must greater than or equal to 1"))
+        ;
+    }
 }

--- a/src/test/java/com/example/myinsta/service/PostsServiceTest.java
+++ b/src/test/java/com/example/myinsta/service/PostsServiceTest.java
@@ -5,6 +5,7 @@ import com.example.myinsta.dao.PostImagesUpdateDao;
 import com.example.myinsta.dao.PostsDao;
 import com.example.myinsta.dao.PostsUpdateDao;
 import com.example.myinsta.dto.PostCreateDto;
+import com.example.myinsta.dto.PostDeleteDto;
 import com.example.myinsta.dto.PostUpdateDto;
 import com.example.myinsta.exception.CustomException;
 import com.example.myinsta.mapper.PostsMapper;
@@ -30,10 +31,12 @@ class PostsServiceTest {
     PostsService postsService;
     PostCreateDto postCreateDto;
     PostUpdateDto postUpdateDto;
+    PostDeleteDto postDeleteDto;
     @BeforeEach
     void setUp() {
         postCreateDto = PostCreateDto.builder().title("This is post title").imageUrl("/this/is/some/url").build();
         postUpdateDto = PostUpdateDto.builder().title("This is post update title").imageUrl("/THis/Is/Update/Path").build();
+        postDeleteDto = PostDeleteDto.builder().idAccount(1L).build();
     }
     @Test
     @DisplayName("insertPost() success insertPostImage() never happen then throw exception")
@@ -74,55 +77,55 @@ class PostsServiceTest {
     @DisplayName("isPostExist() fail isOwner() not happen updatePost() not happen updatePostImage() not happen then throw exception")
     void postUpdate_fail_with_exception1() {
         //given
-        given(postsMapper.isPostExist(any(PostsUpdateDao.class))).willReturn(false);
+        given(postsMapper.isPostExist(any())).willReturn(false);
         //when
         CustomException thrown = assertThrows(CustomException.class, () -> postsService.postUpdate(postUpdateDto, 1L));
         //then
         assertEquals("Post cannot be found",thrown.getErrorCode().getMessage());
-        then(postsMapper).should(atLeastOnce()).isPostExist(any(PostsUpdateDao.class));
+        then(postsMapper).should(atLeastOnce()).isPostExist(any());
     }
     @Test
     @DisplayName("isPostExist() success isOwner() fail updatePost() not happen updatePostImage() not happen then throw exception")
     void postUpdate_fail_with_exception2() {
         //given
-        given(postsMapper.isPostExist(any(PostsUpdateDao.class))).willReturn(true);
-        given(postsMapper.isOwner(any(PostsUpdateDao.class))).willReturn(false);
+        given(postsMapper.isPostExist(any())).willReturn(true);
+        given(postsMapper.isOwner(any())).willReturn(false);
         //when
         CustomException thrown = assertThrows(CustomException.class, () -> postsService.postUpdate(postUpdateDto, 1L));
         //then
         assertEquals("Only post owner can modify post",thrown.getErrorCode().getMessage());
-        then(postsMapper).should(atLeastOnce()).isPostExist(any(PostsUpdateDao.class));
-        then(postsMapper).should(atLeastOnce()).isOwner(any(PostsUpdateDao.class));
+        then(postsMapper).should(atLeastOnce()).isPostExist(any());
+        then(postsMapper).should(atLeastOnce()).isOwner(any());
     }
     @Test
     @DisplayName("isPostExist() success isOwner() success updatePost() fail updatePostImage() not happen then throw exception")
     void postUpdate_fail_with_exception3() {
         //given
-        given(postsMapper.isPostExist(any(PostsUpdateDao.class))).willReturn(true);
-        given(postsMapper.isOwner(any(PostsUpdateDao.class))).willReturn(true);
+        given(postsMapper.isPostExist(any())).willReturn(true);
+        given(postsMapper.isOwner(any())).willReturn(true);
         given(postsMapper.updatePost(any(PostsUpdateDao.class))).willReturn(0);
         //when
         CustomException thrown = assertThrows(CustomException.class, () -> postsService.postUpdate(postUpdateDto, 1L));
         //then
         assertEquals("Post update failed",thrown.getErrorCode().getMessage());
-        then(postsMapper).should(atLeastOnce()).isPostExist(any(PostsUpdateDao.class));
-        then(postsMapper).should(atLeastOnce()).isOwner(any(PostsUpdateDao.class));
+        then(postsMapper).should(atLeastOnce()).isPostExist(any());
+        then(postsMapper).should(atLeastOnce()).isOwner(any());
         then(postsMapper).should(atLeastOnce()).updatePost(any(PostsUpdateDao.class));
     }
     @Test
     @DisplayName("isPostExist() success isOwner() success updatePost() success updatePostImage() fail then throw exception")
     void postUpdate_fail_with_exception4() {
         //given
-        given(postsMapper.isPostExist(any(PostsUpdateDao.class))).willReturn(true);
-        given(postsMapper.isOwner(any(PostsUpdateDao.class))).willReturn(true);
+        given(postsMapper.isPostExist(any())).willReturn(true);
+        given(postsMapper.isOwner(any())).willReturn(true);
         given(postsMapper.updatePost(any(PostsUpdateDao.class))).willReturn(1);
         given(postsMapper.updatePostImage(any(PostImagesUpdateDao.class))).willReturn(0);
         //when
         CustomException thrown = assertThrows(CustomException.class, () -> postsService.postUpdate(postUpdateDto, 1L));
         //then
         assertEquals("Post image update failed",thrown.getErrorCode().getMessage());
-        then(postsMapper).should(atLeastOnce()).isPostExist(any(PostsUpdateDao.class));
-        then(postsMapper).should(atLeastOnce()).isPostExist(any(PostsUpdateDao.class));
+        then(postsMapper).should(atLeastOnce()).isPostExist(any());
+        then(postsMapper).should(atLeastOnce()).isOwner(any());
         then(postsMapper).should(atLeastOnce()).updatePost(any(PostsUpdateDao.class));
         then(postsMapper).should(atLeastOnce()).updatePostImage(any(PostImagesUpdateDao.class));
     }
@@ -130,17 +133,73 @@ class PostsServiceTest {
     @DisplayName("isPostExist() success isOwner() success updatePost() success updatePostImage() success without exception")
     void postUpdate_success_without_exception() {
         //given
-        given(postsMapper.isPostExist(any(PostsUpdateDao.class))).willReturn(true);
-        given(postsMapper.isOwner(any(PostsUpdateDao.class))).willReturn(true);
+        given(postsMapper.isPostExist(any())).willReturn(true);
+        given(postsMapper.isOwner(any())).willReturn(true);
         given(postsMapper.updatePost(any(PostsUpdateDao.class))).willReturn(1);
         given(postsMapper.updatePostImage(any(PostImagesUpdateDao.class))).willReturn(1);
         //when
         postsService.postUpdate(postUpdateDto, 1L);
         //then
-        then(postsMapper).should(atLeastOnce()).isPostExist(any(PostsUpdateDao.class));
-        then(postsMapper).should(atLeastOnce()).isOwner(any(PostsUpdateDao.class));
+        then(postsMapper).should(atLeastOnce()).isPostExist(any());
+        then(postsMapper).should(atLeastOnce()).isOwner(any());
         then(postsMapper).should(atLeastOnce()).updatePost(any(PostsUpdateDao.class));
         then(postsMapper).should(atLeastOnce()).updatePostImage(any(PostImagesUpdateDao.class));
     }
+    @Test
+    @DisplayName("isPostExist() fail isOwner() not happen deletePost() not happen then throw exception")
+    void postDelete_fail_with_exception() {
+        //given
+        given(postsMapper.isPostExist(any())).willReturn(false);
 
+        //when
+        CustomException thrown = assertThrows(CustomException.class, () -> postsService.postDelete(1L, postDeleteDto));
+        //then
+        assertEquals("Post deletion failed post cannot be found",thrown.getErrorCode().getMessage());
+        then(postsMapper).should(atLeastOnce()).isPostExist(any());
+    }
+    @Test
+    @DisplayName("isPostExist() success isOwner() fail deletePost() not happen then throw exception")
+    void postDelete_fail_with_exception2() {
+        //given
+        given(postsMapper.isPostExist(any())).willReturn(true);
+        given(postsMapper.isOwner(any())).willReturn(false);
+
+        //when
+        CustomException thrown = assertThrows(CustomException.class, () -> postsService.postDelete(1L, postDeleteDto));
+        //then
+        assertEquals("Only post owner can delete post",thrown.getErrorCode().getMessage());
+        then(postsMapper).should(atLeastOnce()).isPostExist(any());
+        then(postsMapper).should(atLeastOnce()).isOwner(any());
+    }
+    @Test
+    @DisplayName("isPostExist() success isOwner() success deletePost() fail then throw exception")
+    void postDelete_fail_with_exception3() {
+        //given
+        given(postsMapper.isPostExist(any())).willReturn(true);
+        given(postsMapper.isOwner(any())).willReturn(true);
+        given(postsMapper.deletePost(any())).willReturn(0);
+
+        //when
+        CustomException thrown = assertThrows(CustomException.class, () -> postsService.postDelete(1L, postDeleteDto));
+        //then
+        assertEquals("Post deletion failed",thrown.getErrorCode().getMessage());
+        then(postsMapper).should(atLeastOnce()).isPostExist(any());
+        then(postsMapper).should(atLeastOnce()).isOwner(any());
+        then(postsMapper).should(atLeastOnce()).deletePost(any());
+    }
+    @Test
+    @DisplayName("isPostExist() success isOwner() success deletePost() success without exception")
+    void postDelete_success_without_exception3() {
+        //given
+        given(postsMapper.isPostExist(any())).willReturn(true);
+        given(postsMapper.isOwner(any())).willReturn(true);
+        given(postsMapper.deletePost(any())).willReturn(1);
+
+        //when
+        postsService.postDelete(1L, postDeleteDto);
+        //then
+        then(postsMapper).should(atLeastOnce()).isPostExist(any());
+        then(postsMapper).should(atLeastOnce()).isOwner(any());
+        then(postsMapper).should(atLeastOnce()).deletePost(any());
+    }
 }


### PR DESCRIPTION
[변경사항]
isPostEixst()의 매개변수 PostUpdateDao가 아닌 post의 ID를 받도록 변경; update외에 다른 서비스에서도 필요함
isOwner()의 매개변수 PostUpdateDaot가 아닌 account의 ID를 받도록 변경; update외에 다른 서비스에서도 필요함

[추가사항]
PostDeleteDto
deletePost() end point
deletePost() 서비스 로직
deletePost() SQL 쿼리 추가
deletePost() 관련 에러코드 추가
deletePost() 데이터 유효성 검증 테스트 추가
deletePost() 예외 처리 검증 테스트 추가


